### PR TITLE
Bump faker version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		, "source": "http://github.com/gourmet/faker"
 	}
 	, "require": {
-		"fzaninotto/faker": "1.4.*"
+		"fzaninotto/faker": "1.5.*"
 	}
 	, "require-dev": {
 		"cakephp/cakephp": "3.0.*",


### PR DESCRIPTION
Faker v1.5 includes the `Faker\ORM\CakePHP\EntityPopulator` class, so we no longer get the following error when extending `Gourmet\Faker\TestSuite\Fixture\TestFixture` that occurred with Faker v1.4:

```
PHP Fatal error:  Class 'Faker\ORM\CakePHP\EntityPopulator' not found in /vagrant/vendor/gourmet/faker/src/TestSuite/Fixture/TestFixture.php on line 64
```

Quickly verified the error is gone by running a fixture like this: https://github.com/gourmet/faker#fixture

Fixes #2